### PR TITLE
Clarify PyHC Environment package registry failures

### DIFF
--- a/src/pyhc_actions/env_compat/uv_resolver.py
+++ b/src/pyhc_actions/env_compat/uv_resolver.py
@@ -65,6 +65,22 @@ def _extract_canonical_name_from_spec(spec: str) -> str | None:
         return canonicalize_name(base) if base else None
 
 
+def _find_requirement_for_package(
+    package_name: str | None,
+    requirements: list[str],
+) -> str | None:
+    """Find the requirement entry for a package in a requirement list."""
+    package_name_canonical = _canonicalize_package_name(package_name)
+    if not package_name_canonical:
+        return None
+
+    for requirement in requirements:
+        if _extract_canonical_name_from_spec(requirement) == package_name_canonical:
+            return requirement
+
+    return None
+
+
 def _python_version_for_uv(pyhc_python: str | None) -> str | None:
     """Convert Python version to uv-compatible major.minor form."""
     if not pyhc_python:
@@ -345,6 +361,7 @@ def check_compatibility(
     package_name_canonical = _canonicalize_package_name(package_name)
 
     temp_constraints: str | None = None
+    pyhc_requirements_for_resolution: list[str] = []
 
     # Create temporary package list file combining both
     with tempfile.NamedTemporaryFile(
@@ -363,6 +380,7 @@ def check_compatibility(
             ):
                 continue
 
+            pyhc_requirements_for_resolution.append(req)
             f.write(f"{req}\n")
 
         # Add the package being checked (use -e for local editable install)
@@ -454,6 +472,38 @@ def check_compatibility(
             package_name = pyproject_data.get("project", {}).get("name")
         except Exception:
             package_name = None
+
+        missing_package = _extract_missing_registry_package(result.stderr)
+        missing_pyhc_requirement = _find_requirement_for_package(
+            missing_package, pyhc_requirements_for_resolution
+        )
+        if missing_package and missing_pyhc_requirement:
+            _report_error(
+                package=missing_package,
+                message="PyHC Environment package unavailable from package registry",
+                details=(
+                    "The compatibility check could not finish because the PyHC "
+                    f"Environment currently requires `{missing_pyhc_requirement}`, "
+                    "but uv could not find that package in the configured package "
+                    "registry.\n"
+                    "This is a problem with the PyHC Environment baseline, not "
+                    "evidence that your package depends on that package.\n\n"
+                    "uv reported:\n"
+                    f"{_extract_error_summary(result.stderr)}"
+                ),
+                suggestion=(
+                    "Ask PyHC Environment maintainers to remove, constrain, or "
+                    f"restore `{missing_package}`"
+                ),
+            )
+            return False, [
+                Conflict(
+                    package=missing_package,
+                    your_requirement="(not involved)",
+                    pyhc_requirement=missing_pyhc_requirement,
+                    reason="PyHC Environment package unavailable from package registry",
+                )
+            ]
 
         if _is_unpublished_package_error(result.stderr, package_name):
             _report_error(
@@ -863,6 +913,14 @@ def _is_unpublished_package_error(stderr: str, package_name: str | None = None) 
     ]
 
     stderr_lower = stderr.lower()
+    missing_package = _extract_missing_registry_package(stderr)
+    if missing_package:
+        if package_name:
+            return (
+                _canonicalize_package_name(missing_package)
+                == _canonicalize_package_name(package_name)
+            )
+        return True
 
     # Check if any indicator matches
     for indicator in indicators:
@@ -876,6 +934,22 @@ def _is_unpublished_package_error(stderr: str, package_name: str | None = None) 
                 return True
 
     return False
+
+
+def _extract_missing_registry_package(stderr: str) -> str | None:
+    """Extract the package name when uv reports a package is missing from a registry."""
+    patterns = [
+        r"Because\s+([A-Za-z0-9_.-]+)\s+was\s+not\s+found\s+in\s+the\s+package\s+registry",
+        r"Because\s+there\s+is\s+no\s+version\s+of\s+([A-Za-z0-9_.-]+)(?:\s|[<>=!~]|,)",
+        r"Could\s+not\s+find\s+a\s+version\s+that\s+satisfies\s+the\s+requirement\s+([A-Za-z0-9_.-]+)",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, stderr, re.IGNORECASE)
+        if match:
+            return match.group(1)
+
+    return None
 
 
 def _extract_error_summary(stderr: str) -> str:

--- a/tests/test_compat_checker.py
+++ b/tests/test_compat_checker.py
@@ -972,6 +972,76 @@ error: No solution found:
         result = _is_unpublished_package_error(stderr, "mypackage")
         assert result is False
 
+    def test_extract_package_registry_not_found_error(self):
+        """Test extracting package names from uv registry-not-found errors."""
+        from pyhc_actions.env_compat.uv_resolver import _extract_missing_registry_package
+
+        stderr = """
+× No solution found when resolving dependencies:
+╰─▶ Because astrometry-azel was not found in the package registry and you
+    require astrometry-azel==1.3.0, we can conclude that your requirements
+    are unsatisfiable.
+"""
+        result = _extract_missing_registry_package(stderr)
+        assert result == "astrometry-azel"
+
+    def test_registry_not_found_matches_unpublished_package(self):
+        """Test that uv registry-not-found errors match the package under test."""
+        from pyhc_actions.env_compat.uv_resolver import _is_unpublished_package_error
+
+        stderr = """
+× No solution found when resolving dependencies:
+╰─▶ Because my-package was not found in the package registry and you
+    require my-package, we can conclude that your requirements are unsatisfiable.
+"""
+        assert _is_unpublished_package_error(stderr, "my-package") is True
+        assert _is_unpublished_package_error(stderr, "other-package") is False
+
+    def test_pyhc_environment_missing_package_error_message(self, tmp_path, monkeypatch):
+        """Missing PyHC Environment packages should not be blamed on the user package."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            """
+[project]
+name = "hapiclient"
+"""
+        )
+
+        class DummyResult:
+            returncode = 1
+            stdout = ""
+            stderr = """
+× No solution found when resolving dependencies:
+╰─▶ Because astrometry-azel was not found in the package registry and you
+    require astrometry-azel==1.3.0, we can conclude that your requirements
+    are unsatisfiable.
+"""
+
+        monkeypatch.setattr("pyhc_actions.env_compat.uv_resolver.find_uv", lambda: "/usr/bin/uv")
+        monkeypatch.setattr("pyhc_actions.env_compat.uv_resolver.subprocess.run", lambda *a, **k: DummyResult())
+
+        reporter = Reporter(title="Test", output=StringIO(), github_actions=False)
+        ok, conflicts = check_compatibility(
+            pyproject_path=pyproject,
+            pyhc_packages=["astrometry-azel==1.3.0", "numpy>=2"],
+            pyhc_constraints=[],
+            pyhc_python="3.12.0",
+            reporter=reporter,
+        )
+
+        assert ok is False
+        assert len(conflicts) == 1
+        assert conflicts[0].package == "astrometry-azel"
+        assert conflicts[0].your_requirement == "(not involved)"
+        assert conflicts[0].pyhc_requirement == "astrometry-azel==1.3.0"
+        assert len(reporter.errors) == 1
+        assert (
+            reporter.errors[0].message
+            == "PyHC Environment package unavailable from package registry"
+        )
+        assert "not evidence that your package depends on that package" in reporter.errors[0].details
+        assert "astrometry-azel==1.3.0" in reporter.errors[0].details
+
 
 class TestParseResolvedVersions:
     """Tests for parsing resolved package versions from uv output."""


### PR DESCRIPTION
## Motivation

A downstream user reported a confusing PyHC Environment compatibility-check failure after `astrometry-azel` disappeared from PyPI. The checker surfaced uv's resolver text as though the checked package required `astrometry-azel`, even though that requirement came from the PyHC Environment baseline package list.

That made the user-facing error misleading: the checker could not finish because an environment package was unavailable from the package registry, not because the downstream project depended on it.

## What changed

- Parse uv registry/unavailable-package messages to extract the missing package name.
- Compare the missing package against the PyHC Environment requirements actually sent to uv for that resolution.
- When the missing package comes from the PyHC Environment baseline, report `PyHC Environment package unavailable from package registry`.
- Mark the downstream package requirement as `(not involved)` in the generated conflict, and explain that the failure is not evidence that the checked package depends on the missing package.
- Preserve the existing unpublished-package handling for the package under test.
- Add regression coverage for the `astrometry-azel`/PyPI-removal style error message.

## Validation

- `python -m pytest tests/test_compat_checker.py::TestUnpublishedPackageError -q` -> 7 passed
- `python -m pytest -q` -> 205 passed
- `git diff --check`